### PR TITLE
Update New Relic PHP Agent to v6.6.1.172

### DIFF
--- a/lumen-php-fpm/Dockerfile
+++ b/lumen-php-fpm/Dockerfile
@@ -9,7 +9,7 @@ ADD ./newrelic.ini /usr/local/etc/php/conf.d
 
 # Environment variables
 ENV PHP_API_VERSION 20151012
-ENV NEWRELIC_VERSION 6.4.0.163
+ENV NEWRELIC_VERSION 6.6.1.172
 
 # Install dependencies
 RUN apk --no-cache --update --repository http://dl-3.alpinelinux.org/alpine/edge/community/ add \


### PR DESCRIPTION
Lots of bugs fixes and improvements since v6.4.0.163.

Especially important for us is Laravel/Lumen 5.3 support, support for Laravel Queue and PDO bug fixes.

See https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes
