### PR TITLE
Bump node-workspace dependencies

### DIFF
--- a/node-workspace/Dockerfile
+++ b/node-workspace/Dockerfile
@@ -2,6 +2,9 @@ FROM node:6.8
 
 MAINTAINER Sebastian Mandrean <sebastian@urb-it.com>
 
+# Environment variables
+ENV PHANTOMJS_VERSION 2.1.13
+
 # Install dependencies
 RUN apt-get -y update \
  && apt-get -y install \
@@ -9,7 +12,7 @@ RUN apt-get -y update \
 	libelf-dev \
  && npm i -g \
 	yarn \
-	phantomjs
+	phantomjs-prebuilt@PHANTOMJS_VERSION
 
 # Clean up
 RUN rm -rf /var/cache/apt/archives

--- a/node-workspace/Dockerfile
+++ b/node-workspace/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get -y update \
 	libelf-dev \
  && npm i -g \
 	yarn \
-	webpack \
 	phantomjs
 
 # Clean up

--- a/node-workspace/Dockerfile
+++ b/node-workspace/Dockerfile
@@ -3,6 +3,7 @@ FROM node:6.8
 MAINTAINER Sebastian Mandrean <sebastian@urb-it.com>
 
 # Environment variables
+ENV YARN_VERSION 0.18.0
 ENV PHANTOMJS_VERSION 2.1.13
 
 # Install dependencies
@@ -11,7 +12,7 @@ RUN apt-get -y update \
 	ocaml \
 	libelf-dev \
  && npm i -g \
-	yarn \
+	yarn@YARN_VERSION \
 	phantomjs-prebuilt@PHANTOMJS_VERSION
 
 # Clean up

--- a/node-workspace/Dockerfile
+++ b/node-workspace/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get -y update \
 	ocaml \
 	libelf-dev \
  && npm i -g \
-	yarn@YARN_VERSION \
-	phantomjs-prebuilt@PHANTOMJS_VERSION
+	yarn@$YARN_VERSION \
+	phantomjs-prebuilt@$PHANTOMJS_VERSION
 
 # Clean up
 RUN rm -rf /var/cache/apt/archives


### PR DESCRIPTION
- `webpack` is not needed as a global dependency
- `phantomjs` was deprecated in favor of `phantomjs-prebuilt`
- specify versions for `phantom` and `yarn`