### PR TITLE
Add bcmath extension to lumen-php-cli

### DIFF
--- a/lumen-php-cli/Dockerfile
+++ b/lumen-php-cli/Dockerfile
@@ -7,7 +7,7 @@ ENV MONGODB_VERSION=1.1.8
 # Install dependencies & clean up
 RUN apk --no-cache --update --repository http://dl-3.alpinelinux.org/alpine/edge/community/ add \
     php7-sockets \
-    php7-intl \
+    php7-bcmath \
     curl \
     openssl-dev \
     openssl \
@@ -23,6 +23,7 @@ RUN pecl install \
     pdo_mysql \
     sockets \
     intl \
+    bcmath \
 && docker-php-ext-enable \
     mongodb
 

--- a/lumen-php-fpm/Dockerfile
+++ b/lumen-php-fpm/Dockerfile
@@ -48,7 +48,6 @@ RUN apk --no-cache --update --repository http://dl-cdn.alpinelinux.org/alpine/v$
     php7-gd \
     php7-sockets \
     php7-zlib \
-    php7-intl \
     php7-opcache \
     php7-bcmath \
 && apk --no-cache --update --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --repository http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/main/ add \


### PR DESCRIPTION
`php artisan etas:update` cron command was failing because of missing extension.

Also noticed due to the latest pkg updates, the `php7-intl` package requires a new version of icu (58.2-r1) which was causing dependency breaks. 

Removed `apk add php7-intl` and left only `docker-php-ext-install intl` which uses the version that comes bundled with php7.0-apline.

![screen shot 2017-01-12 at 12 05 26](https://cloud.githubusercontent.com/assets/4922271/21888450/a1879cfa-d8c4-11e6-8928-6a193f299159.png)

Tested it locally running the application and it worked perfectly 👌 