### PR TITLE
Remove manual yarn installation from node-workspace (IO-58)

### DIFF
--- a/node-workspace/Dockerfile
+++ b/node-workspace/Dockerfile
@@ -3,19 +3,10 @@ FROM node:6.10
 MAINTAINER Sebastian Mandrean <sebastian@urb-it.com>
 
 # Environment variables
-ENV YARN_VERSION 0.21.3
 ENV PHANTOMJS_VERSION 2.1.14
 
 # Install dependencies
-RUN apt-get -y update \
- && apt-get -y install \
-	ocaml \
-	libelf-dev \
- && npm i -g \
-	yarn@$YARN_VERSION \
+RUN npm i -g \
 	phantomjs-prebuilt@$PHANTOMJS_VERSION
-
-# Clean up
-RUN rm -rf /var/cache/apt/archives
 
 WORKDIR /home

--- a/node-workspace/Dockerfile
+++ b/node-workspace/Dockerfile
@@ -6,7 +6,12 @@ MAINTAINER Sebastian Mandrean <sebastian@urb-it.com>
 ENV PHANTOMJS_VERSION 2.1.14
 
 # Install dependencies
-RUN npm i -g \
-	phantomjs-prebuilt@$PHANTOMJS_VERSION
+RUN apt-get -y update \
+ && apt-get -y install \
+	ocaml \
+	libelf-dev \
+ && npm i -g \
+	phantomjs-prebuilt@$PHANTOMJS_VERSION \
+ && rm -rf /var/cache/apt/archives
 
 WORKDIR /home

--- a/node-workspace/Dockerfile
+++ b/node-workspace/Dockerfile
@@ -6,12 +6,11 @@ MAINTAINER Sebastian Mandrean <sebastian@urb-it.com>
 ENV PHANTOMJS_VERSION 2.1.14
 
 # Install dependencies
-RUN apt-get -y update \
- && apt-get -y install \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 	ocaml \
 	libelf-dev \
  && npm i -g \
 	phantomjs-prebuilt@$PHANTOMJS_VERSION \
- && rm -rf /var/cache/apt/archives
+&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 WORKDIR /home


### PR DESCRIPTION
https://urb-it.atlassian.net/browse/IO-58

Now yarn is installed upstream, so we don't need to duplicate its installation. See:
https://github.com/nodejs/docker-node/blob/debf4ea17cee8c078df632e975ea69f1969094c0/6.10/Dockerfile#L33-L46