### PR TITLE
Improve openresty lua rng seed

### DIFF
--- a/openresty-gateway/nginx.conf
+++ b/openresty-gateway/nginx.conf
@@ -16,6 +16,33 @@ http {
     include             /usr/local/openresty/nginx/conf/mime.types;
     include /usr/local/api-gateway/nginx/upstream/*.conf;
     include /usr/local/api-gateway/nginx/defaults.conf;
+    init_worker_by_lua_block {
+        local function split(str, pat)
+            local t = {}
+            local fpat = '(.-)' .. pat
+            local last_end = 1
+            local s, e, cap = str:find(fpat, 1)
+            while s do
+                if s ~= 1 or cap ~= '' then
+                    table.insert(t,cap)
+                end
+                last_end = e+1
+                s, e, cap = str:find(fpat, last_end)
+            end
+            if last_end <= #str then
+                cap = str:sub(last_end)
+                table.insert(t, cap)
+            end
+            return t
+        end
+        local uuid = require 'resty.jit-uuid'
+        local crc = 0
+        for line in io.lines('/proc/self/cgroup') do
+            local parts = split(line, '[\\/]+')
+            crc = ngx.crc32_short(parts[#parts])
+        end
+        uuid.seed(ngx.time() + ngx.worker.pid() + crc)
+    }
     server {
         listen       80 default_server;
         server_name  localhost;


### PR DESCRIPTION
Seed the lua rng with the sum of current time, worker process id and the crc of the docker container id