### PR TITLE
Add process control timeout to lumen php fpm image

### DIFF
--- a/lumen-php-fpm/Dockerfile
+++ b/lumen-php-fpm/Dockerfile
@@ -12,6 +12,8 @@ ADD ./lumen.ini $PHP_INI_DIR/conf.d
 ADD ./lumen.pool.conf /usr/local/etc/php-fpm.d
 RUN rm /usr/local/etc/php-fpm.d/www.conf*
 
+RUN sed -i "s|;process_control_timeout = 0|process_control_timeout = 30|g" $PHP_INI_DIR/../php-fpm.conf
+
 # Environment variables
 ENV ALPINE_VERSION 3.10
 ENV PHP_API_VERSION 20160303


### PR DESCRIPTION
### Why ?
As a developer i want to be able to deploy php services without having requests fail.

### What ?
Add a process control timeout config setting so that workers will wait up to 30 seconds for requests to finish before terminating