### PR TITLE
Static-nginx-serve-static-gzip

### DIFF
--- a/static-nginx/Dockerfile
+++ b/static-nginx/Dockerfile
@@ -1,7 +1,5 @@
 FROM nginx:stable-alpine
 
-MAINTAINER Denis Koltsov <denis@urbit.com>
-
 COPY auto-reload-nginx.sh /home/auto-reload-nginx.sh
 COPY nginx.conf /etc/nginx/
 COPY default.conf /etc/nginx/conf.d/default.conf

--- a/static-nginx/Dockerfile
+++ b/static-nginx/Dockerfile
@@ -16,7 +16,8 @@ RUN apk --no-cache --update --repository http://dl-3.alpinelinux.org/alpine/edge
 && rm -rf /var/cache/apk/* /tmp/*
 
 # Set up user
-RUN addgroup -S www-data \
+RUN (delgroup www-data || true) && \
+addgroup -S www-data \
 && adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx www-data \
 && usermod -u 1000 www-data
 

--- a/static-nginx/Dockerfile
+++ b/static-nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine
+FROM nginx:1.20.1-alpine
 
 COPY auto-reload-nginx.sh /home/auto-reload-nginx.sh
 COPY nginx.conf /etc/nginx/

--- a/static-nginx/nginx.conf
+++ b/static-nginx/nginx.conf
@@ -21,6 +21,7 @@ http {
   access_log /var/log/nginx/access.log;
   error_log /var/log/nginx/error.log;
   gzip on;
+  gzip_static on;
   gzip_disable "msie6";
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/sites-available/*;


### PR DESCRIPTION
## Why?
As a Business portal user
In order to place deliveries as fast as possible
I want to get the static files served with gzip compression

## What?
- Add [gzip_static](https://docs.nginx.com/nginx/admin-guide/web-server/compression/#sending-compressed-files) which serves pre-compressed files.

## Note
This change is mainly done for the Business portal, which has compressed its files for years, but it has probably always served the uncompressed files.

I don't think this Docker image is used in any other place. Please let me know in the comments if that's not the case. Also remember to like, subscribe and share this PR with your friends. It would really help the contributors of this repo :heart:

## Screenshots

Testing locally with the Business Portal with this simple docker-compose config:
```
web:
  image: static-nginx-local:gzip
  volumes:
    - ./public:/var/www/application/public
  ports:
    - "8080:80"
```

_File names are different because I'm testing out other stuff in BP at the same time, but file contents are basically the same._

### No compression

<img width="1060" alt="Screenshot 2021-11-03 at 22 03 35" src="https://user-images.githubusercontent.com/696747/140192834-e91c234a-a415-499e-8e58-153436b6e338.png">

### With compression

<img width="1083" alt="Screenshot 2021-11-03 at 22 00 14" src="https://user-images.githubusercontent.com/696747/140192868-e5ea0ac8-0885-471c-9000-56224e993da1.png">