### PR TITLE
Update openresty image to work with non root users

### DIFF
--- a/openresty-gateway/Dockerfile
+++ b/openresty-gateway/Dockerfile
@@ -1,6 +1,4 @@
-FROM openresty/openresty:alpine
-
-MAINTAINER Jonas Odencrants <jonas.odencrants@urbit.com>
+FROM openresty/openresty:1.17.8.2-5-alpine
 
 # Copy files & set permissions
 COPY nginx.conf /usr/local/openresty/nginx/conf/
@@ -42,5 +40,5 @@ RUN opm install chunpu/shim pintsized/lua-resty-http sumory/lor bungle/lua-resty
 
 WORKDIR /usr/local/api-gateway
 
-EXPOSE 80 443
+EXPOSE 8080
 

--- a/openresty-gateway/nginx.conf
+++ b/openresty-gateway/nginx.conf
@@ -10,13 +10,13 @@ events {
 }
 
 include /usr/share/nginx/modules/*.conf;
-
+pid /tmp/nginx.pid;
 http {
     include /usr/local/openresty/nginx/conf/mime.types;
     include /usr/local/api-gateway/nginx/upstream/*.conf;
     include /usr/local/api-gateway/nginx/defaults.conf;
     server {
-        listen       80 default_server;
+        listen       8080 default_server;
         server_name  localhost;
         root         /usr/share/nginx/html;
 


### PR DESCRIPTION
### Why ?
Why?
To reduce the risk of attacks, we want to make our container more secure.

What?
Use a non restricted port for openresty so we can run it as non root users.
Move the nginx.pid file to /tmp