### PR TITLE
Update lumen nginx and prooph-worker images (Non root)

### DIFF
--- a/lumen-nginx/Dockerfile
+++ b/lumen-nginx/Dockerfile
@@ -1,8 +1,9 @@
-FROM nginx:1.10.0-alpine
-
-MAINTAINER Sebastian Mandrean <sebastian@urb-it.com>
+FROM nginx:1.21.5-alpine
 
 ARG PHP_UPSTREAM=php-fpm
+
+ARG UID=1000
+ARG GID=2000
 
 COPY auto-reload-nginx.sh /home/auto-reload-nginx.sh
 COPY nginx.conf /etc/nginx/
@@ -22,12 +23,22 @@ RUN apk --no-cache --update --repository http://dl-3.alpinelinux.org/alpine/edge
 && rm -rf /var/cache/apk/* /tmp/*
 
 # Set up user
-RUN addgroup -S www-data \
-&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx www-data \
-&& usermod -u 1000 www-data
+
+RUN deluser nginx || true \
+    && delgroup nginx || true \
+    && addgroup -g $GID -S nginx || true \
+    && adduser -u $UID -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx || true
+
+RUN chown nginx /home/auto-reload-nginx.sh \
+    && chown -R $UID:0 /var/cache/nginx \
+    && chmod -R g+w /var/cache/nginx \
+    && chown -R $UID:0 /etc/nginx \
+    && chmod -R g+w /etc/nginx
 
 CMD ["/home/auto-reload-nginx.sh"]
 
 WORKDIR /var/www/application
 
-EXPOSE 80 443
+USER nginx
+
+EXPOSE 8080

--- a/lumen-nginx/lumen.conf
+++ b/lumen-nginx/lumen.conf
@@ -1,6 +1,6 @@
 server {
-    listen 80 default_server;
-    listen [::]:80 default_server ipv6only=on;
+    listen 8080 default_server;
+    listen [::]:8080 default_server ipv6only=on;
 
     client_max_body_size 8M;
 

--- a/lumen-nginx/nginx.conf
+++ b/lumen-nginx/nginx.conf
@@ -1,6 +1,6 @@
-user www-data;
+user nginx;
 worker_processes 4;
-pid /run/nginx.pid;
+pid /tmp/nginx.pid;
 daemon off;
 
 events {
@@ -20,6 +20,13 @@ http {
   default_type application/octet-stream;
   gzip on;
   gzip_disable "msie6";
+
+  client_body_temp_path /tmp/nginx_client_body_temp;
+  proxy_temp_path /tmp/nginx_proxy_temp;
+  fastcgi_temp_path /tmp/nginx_fast_cgi_temp;
+  uwsgi_temp_path /tmp/nginx_uwsgi_temp;
+  scgi_temp_path /tmp/nginx_scgi_temp;
+
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/sites-available/*;
   map $request $loggable {

--- a/prooph-worker/Dockerfile
+++ b/prooph-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-alpine3.10
+FROM php:7.3-alpine3.13
 
 MAINTAINER Urbit <pd@urb-it.com>
 
@@ -7,11 +7,11 @@ ADD ./prooph.ini /usr/local/etc/php/conf.d
 ADD ./worker.conf /etc/supervisor/worker.conf
 
 # Environment variables
-ENV ALPINE_VERSION 3.10
+ENV ALPINE_VERSION 3.13
 ENV PHP_API_VERSION 20160303
-ENV PYTHON_VERSION=2.7.16-r1
-ENV PY_PIP_VERSION=18.1-r0
-ENV SUPERVISOR_VERSION=3.3.1
+ENV PYTHON_VERSION=3.8.10-r0
+ENV PY_PIP_VERSION=20.3.4-r0
+ENV SUPERVISOR_VERSION=4.2.4
 ENV MONGODB_VERSION=1.6.1
 ENV PHP_AMQP_VERSION=1.9.4
 
@@ -23,20 +23,20 @@ RUN apk --no-cache --update --repository http://dl-cdn.alpinelinux.org/alpine/v$
     autoconf \
     build-base \
     ca-certificates \
-    python2=$PYTHON_VERSION \
-    py2-pip=$PY_PIP_VERSION \
-&& apk --no-cache --update --repository http://dl-3.alpinelinux.org/alpine/edge/main/ add \
+    python3=$PYTHON_VERSION \
+    py3-pip=$PY_PIP_VERSION \
     curl \
-    libressl \
-    libressl-dev \
+    openssl \
+    openssl-dev \
     rabbitmq-c \
     rabbitmq-c-dev \
     libtool \
     icu \
     icu-libs \
     icu-dev \
-    libwebp \
-&& apk --no-cache --update --repository http://dl-3.alpinelinux.org/alpine/edge/community/ add \
+    libwebp
+
+RUN apk --no-cache --update --repository http://dl-3.alpinelinux.org/alpine/v$ALPINE_VERSION/community/ add \
     php7-sockets \
     php7-zlib \
     php7-intl \
@@ -65,12 +65,14 @@ RUN apk --no-cache --update --repository http://dl-cdn.alpinelinux.org/alpine/v$
 && rm -rf /var/cache/apk/* /tmp/* ./newrelic-php5-$NEWRELIC_VERSION-linux-musl*
 
 # Install supervisor
-RUN pip install supervisor==$SUPERVISOR_VERSION
+RUN pip3 install supervisor==$SUPERVISOR_VERSION
 
 WORKDIR /var/www/application
 
-RUN && addgroup -g $GID -S prooph || true \
+RUN addgroup -g $GID -S prooph || true \
     && adduser -u $UID -D -S -h /var/cache/nginx -s /sbin/nologin -G prooph prooph || true
+
+RUN chown -R prooph:prooph /var/www/application
 
 USER prooph
 RUN touch /var/www/application/supervisord.log

--- a/prooph-worker/Dockerfile
+++ b/prooph-worker/Dockerfile
@@ -15,6 +15,9 @@ ENV SUPERVISOR_VERSION=3.3.1
 ENV MONGODB_VERSION=1.6.1
 ENV PHP_AMQP_VERSION=1.9.4
 
+ARG UID=1000
+ARG GID=2000
+
 # Install & clean up dependencies
 RUN apk --no-cache --update --repository http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/main/ add \
     autoconf \
@@ -66,4 +69,9 @@ RUN pip install supervisor==$SUPERVISOR_VERSION
 
 WORKDIR /var/www/application
 
+RUN && addgroup -g $GID -S prooph || true \
+    && adduser -u $UID -D -S -h /var/cache/nginx -s /sbin/nologin -G prooph prooph || true
+
+USER prooph
+RUN touch /var/www/application/supervisord.log
 CMD sh -c "supervisord --nodaemon --configuration /etc/supervisor/worker.conf"


### PR DESCRIPTION
### Why ?
To reduce the risk of attacks, we want to make our container more secure.

### What?
set user to nginx for lumen-nginx image
run lumen-nginx container on port 8080
move nginx temp paths to /tmp
Update some prooph-worker dependencies so we can build the image
set user to prooph for prooph worker and fix permissions