### PR TITLE
Turn off Nginx access logs

### DIFF
--- a/static-nginx/default.conf
+++ b/static-nginx/default.conf
@@ -2,6 +2,8 @@ server {
     listen 8080 default_server;
     listen [::]:8080 default_server ipv6only=on;
 
+    access_log off;
+
     client_max_body_size 8M;
 
     root /var/www/application/public;


### PR DESCRIPTION
## Why?
As a developer
In order to not get spammed with logs
I want to turn off Nginx access logs since Traefik already logs incoming requests

## What?
- This will only affect BP since My Delivery uses it's own custom conf that already has this turned off